### PR TITLE
Support for implicit `$eq`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Exported functions:
 Example:
 
     var jc = require('json-criteria')
-    console.log(jc.test({ foo: bar: 123 }, { 'foo.bar': { $eq: 123 } })) // true
+    console.log(jc.test({ foo: bar: 123 }, { 'foo.bar': 123 })) // true
     console.log(jc.test({ foo: bar: 123 }, { 'foo.bar': { $lt: 100 } })) // false
 
 Criteria queries follow MongoDB convention. You can use operators described at http://docs.mongodb.org/manual/reference/operator/query
@@ -30,6 +30,7 @@ Criteria queries follow MongoDB convention. You can use operators described at h
   * `{ $nor: [ ... ] }` - none of
   * `{ $not: ... }` - not, ie. `{ $not: { $gt: 0, $lt: 1 } }`
 * comparison ops
+  * `{ field: ... }` - same as `$eq` for scalar values
   * `{ field: { $eq: ... } }` - is equal
   * `{ field: { $ne: ... } }` - is not equal
   * `{ field: { $gt: ... } }` - is greater than
@@ -54,7 +55,6 @@ Criteria queries follow MongoDB convention. You can use operators described at h
 
 Not supported:
 
-* `{ filed: value }` - implicit equality is not supported, use: `{ field: { $eq: ... } }` explicit equality operator instead.
 * `{ field: { $eq: { foo: ..., bar: ... } } }` - equality with deep object values are not supported yet, use scalar values instead.
 
 Example criteria queries:
@@ -63,6 +63,7 @@ Example criteria queries:
 |---------------------|-------------------------------------|--------|
 | { foo: bar: 'abc' } | { 'foo.bar': $exists: true }        | true   |
 | { foo: bar: 'abc' } | { 'foo.baz': $exists: true }        | false  |
+| { foo: bar: 'abc' } | { 'foo.bar': 'abc' }                | true   |
 | { foo: bar: 'abc' } | { 'foo.bar': { $eq: 'abc' } }       | true   |
 | { foo: bar: 1 }     | { 'foo.bar': { $gt: 0 } }           | true   |
 | { foo: bar: 1 }     | { 'foo.bar': { $gt: 0, $lt: 1 } }   | false  |

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,15 @@
 (function() {
-  var arrize, assert, assert_, pre, resolve, test,
+  var arrize, assert, assert_, isScalar, pre, resolve, test,
     __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   resolve = require('rus-diff').resolve;
 
   assert = require('assert');
+
+  isScalar = function(v) {
+    var _ref;
+    return (v === null) || ((_ref = typeof v) === 'string' || _ref === 'number' || _ref === 'boolean');
+  };
 
   arrize = function(a) {
     if (Array.isArray(a)) {
@@ -87,6 +92,11 @@
             if (k[0] !== '$') {
               _ref = resolve(d, k), dvp = _ref[0], dk = _ref[1];
               if ((dvp != null) && dk.length === 1) {
+                if (isScalar(v)) {
+                  v = {
+                    $eq: v
+                  };
+                }
                 return test(dvp[dk[0]], v);
               } else {
                 return test(null, v);

--- a/spec/spec-index.coffee
+++ b/spec/spec-index.coffee
@@ -242,6 +242,18 @@ describe 'test', ->
 
   describe 'others and corner cases', ->
 
+    it 'should match implicit $eq', ->
+      y { foo: 'foo' }, { foo: 'foo' }
+      n { foo: 'foo' }, { foo: 'bar' }
+      y { foo: 1 }, { foo: 1 }
+      n { foo: 1 }, { foo: 2 }
+      y { foo: true }, { foo: true }
+      n { foo: true }, { foo: false }
+      y { foo: null }, { foo: null }
+      n { foo: 'foo' }, { foo: null }
+      y { foo: 'foo', bar: 'bar' }, { foo: 'foo', bar: 'bar' }
+      n { foo: 'foo', bar: 'bar' }, { foo: 'bar', bar: 'bar' }
+
     it 'should match range', ->
       y { foo: bar: 1 }, { 'foo.bar': { $gt: 0, $lte: 1 } }
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,6 +2,7 @@
 { resolve } = require 'rus-diff'
 assert = require 'assert'
 
+isScalar = (v) -> (v is null) or (typeof v in ['string', 'number', 'boolean'])
 arrize = (a) -> if Array.isArray(a) then a else [ a ]
 
 # @param [Object] d Document
@@ -9,6 +10,7 @@ arrize = (a) -> if Array.isArray(a) then a else [ a ]
 # @return [Boolean] true on match, false otherwise
 test = (d, q) ->
   r = true
+
   for k, v of q
     s = switch k
 
@@ -50,6 +52,7 @@ test = (d, q) ->
         unless k[0] is '$'
           [ dvp, dk ] = resolve d, k
           if dvp? and dk.length is 1 # ...is resolved
+            if isScalar v then v = { $eq: v } # Implicit $eq
             test dvp[dk[0]], v
           else
             test null, v # we can match $exists false.


### PR DESCRIPTION
This commit adds support for matching scalars with `$eq` implicitly:

``` js
var doc = { foo: 123, bar: 'abc', baz: true, asd: null };
jc.test(doc, { foo: 123, asd: null }) // => true
jc.test(doc, { asd: 'baz' }) // => false
```

It works with scalar values only – strings, numbers, booleans and null. Internally, scalars are eventually normalized to `{ $eq: value }`.

Also included are tests and updates to the docs.
